### PR TITLE
feat: Add typings and simplify code

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,17 @@
         "@typescript-eslint"
     ],
     "rules": {
-        "semi":"error"
+        "semi":"error",
+        "import/extensions": [
+            "error",
+            "ignorePackages",
+            {
+                "js": "never",
+                "jsx": "never",
+                "ts": "never",
+                "tsx": "never"
+            }
+        ]
     },
     "settings": {
         "import/resolver": {

--- a/README.md
+++ b/README.md
@@ -10,19 +10,9 @@ const linguist = require('linguist');
 ```
 
 ```javascript
-// non case-sensitive
-linguist.GetHexColour('javascript');
-
->#f1e05a
-
 linguist.GetHexColour('Swift');
 
 >#ffac45
-
-// for languages that don't exist, `#000` (black) is returned
-linguist.GetHexColour('unobtanium');
-
->#000
 ```
 
 You can also simply return the underlying map itself if you wish:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Querying GitHub linguist language colours from JavaScript or TypeScript",
   "main": "/src/linguist.ts",
   "types": "/src/index.d.ts",
+  "type": "module",
   "repository": "git@github.com:Reeceeboii/github-linguist-colours.git",
   "author": "Reece Mercer <reecemercer981@gmail.com>",
   "license": "MIT",

--- a/src/linguist.ts
+++ b/src/linguist.ts
@@ -1,18 +1,11 @@
-const linguistJSON = require('./linguistData');
+import { Colors, colors } from './linguistData';
 
-const colorMap = new Map<string, string>();
-
-// put colours and langs into a map
-Object.keys(linguistJSON.default).forEach((key: any) => {
-  colorMap.set(key.toLowerCase(), linguistJSON.default[key].color);
-});
-
-// given a string, return the hex colour, or hex black if it is not found
-export function GetHexColour(lang: string): string {
-  return colorMap.get(lang.toLowerCase()) || '#000';
+// given a string, return the hex colour
+export function getHexColour(lang: Colors): string {
+  return colors[lang];
 }
 
-// return the entire colour map
-export function GetColourMap(): Map<string, string> {
-  return colorMap;
+// return the entire colours map
+export function getColourMap() {
+  return colors;
 }

--- a/src/linguistData.ts
+++ b/src/linguistData.ts
@@ -1,958 +1,322 @@
-export default (
-  {
-  '1C Enterprise': {
-    color: '#814CCC',
-  },
-  ABAP: {
-    color: '#E8274B',
-  },
-  'ABAP CDS': {
-    color: '#555e25',
-  },
-  'AGS Script': {
-    color: '#B9D9FF',
-  },
-  AL: {
-    color: '#3AA2B5',
-  },
-  AMPL: {
-    color: '#E6EFBB',
-  },
-  ANTLR: {
-    color: '#9DC3FF',
-  },
-  'API Blueprint': {
-    color: '#2ACCA8',
-  },
-  APL: {
-    color: '#5A8164',
-  },
-  'ASP.NET': {
-    color: '#9400ff',
-  },
-  ATS: {
-    color: '#1ac620',
-  },
-  ActionScript: {
-    color: '#882B0F',
-  },
-  Ada: {
-    color: '#02f88c',
-  },
-  Agda: {
-    color: '#315665',
-  },
-  Alloy: {
-    color: '#64C800',
-  },
-  AngelScript: {
-    color: '#C7D7DC',
-  },
-  Apex: {
-    color: '#1797c0',
-  },
-  'Apollo Guidance Computer': {
-    color: '#0B3D91',
-  },
-  AppleScript: {
-    color: '#101F1F',
-  },
-  Arc: {
-    color: '#aa2afe',
-  },
-  AspectJ: {
-    color: '#a957b0',
-  },
-  Assembly: {
-    color: '#6E4C13',
-  },
-  Asymptote: {
-    color: '#ff0000',
-  },
-  AutoHotkey: {
-    color: '#6594b9',
-  },
-  AutoIt: {
-    color: '#1C3552',
-  },
-  Ballerina: {
-    color: '#FF5000',
-  },
-  Batchfile: {
-    color: '#C1F12E',
-  },
-  Beef: {
-    color: '#a52f4e',
-  },
-  Bison: {
-    color: '#6A463F',
-  },
-  Blade: {
-    color: '#f7523f',
-  },
-  BlitzMax: {
-    color: '#cd6400',
-  },
-  Boo: {
-    color: '#d4bec1',
-  },
-  Boogie: {
-    color: '#c80fa0',
-  },
-  Brainfuck: {
-    color: '#2F2530',
-  },
-  Browserslist: {
-    color: '#ffd539',
-  },
-  C: {
-    color: '#555555',
-  },
-  'C#': {
-    color: '#178600',
-  },
-  'C++': {
-    color: '#f34b7d',
-  },
-  CSON: {
-    color: '#244776',
-  },
-  CSS: {
-    color: '#563d7c',
-  },
-  Ceylon: {
-    color: '#dfa535',
-  },
-  Chapel: {
-    color: '#8dc63f',
-  },
-  Cirru: {
-    color: '#ccccff',
-  },
-  Clarion: {
-    color: '#db901e',
-  },
-  'Classic ASP': {
-    color: '#6a40fd',
-  },
-  Clean: {
-    color: '#3F85AF',
-  },
-  Click: {
-    color: '#E4E6F3',
-  },
-  Clojure: {
-    color: '#db5855',
-  },
-  'Closure Templates': {
-    color: '#0d948f',
-  },
-  CoffeeScript: {
-    color: '#244776',
-  },
-  ColdFusion: {
-    color: '#ed2cd6',
-  },
-  'ColdFusion CFC': {
-    color: '#ed2cd6',
-  },
-  'Common Lisp': {
-    color: '#3fb68b',
-  },
-  'Common Workflow Language': {
-    color: '#B5314C',
-  },
-  'Component Pascal': {
-    color: '#B0CE4E',
-  },
-  Crystal: {
-    color: '#000100',
-  },
-  Cuda: {
-    color: '#3A4E3A',
-  },
-  D: {
-    color: '#ba595e',
-  },
-  DM: {
-    color: '#447265',
-  },
-  Dafny: {
-    color: '#FFEC25',
-  },
-  Dart: {
-    color: '#00B4AB',
-  },
-  DataWeave: {
-    color: '#003a52',
-  },
-  Dhall: {
-    color: '#dfafff',
-  },
-  Dockerfile: {
-    color: '#384d54',
-  },
-  Dogescript: {
-    color: '#cca760',
-  },
-  Dylan: {
-    color: '#6c616e',
-  },
-  E: {
-    color: '#ccce35',
-  },
-  ECL: {
-    color: '#8a1267',
-  },
-  EJS: {
-    color: '#a91e50',
-  },
-  EQ: {
-    color: '#a78649',
-  },
-  Eiffel: {
-    color: '#4d6977',
-  },
-  Elixir: {
-    color: '#6e4a7e',
-  },
-  Elm: {
-    color: '#60B5CC',
-  },
-  'Emacs Lisp': {
-    color: '#c065db',
-  },
-  EmberScript: {
-    color: '#FFF4F3',
-  },
-  Erlang: {
-    color: '#B83998',
-  },
-  'F#': {
-    color: '#b845fc',
-  },
-  'F*': {
-    fs_name: 'Fstar',
-    color: '#572e30',
-  },
-  FLUX: {
-    color: '#88ccff',
-  },
-  Factor: {
-    color: '#636746',
-  },
-  Fancy: {
-    color: '#7b9db4',
-  },
-  Fantom: {
-    color: '#14253c',
-  },
-  Faust: {
-    color: '#c37240',
-  },
-  Forth: {
-    color: '#341708',
-  },
-  Fortran: {
-    color: '#4d41b1',
-  },
-  FreeMarker: {
-    color: '#0050b2',
-  },
-  Frege: {
-    color: '#00cafe',
-  },
-  Futhark: {
-    color: '#5f021f',
-  },
-  'G-code': {
-    color: '#D08CF2',
-  },
-  GAML: {
-    color: '#FFC766',
-  },
-  GDScript: {
-    color: '#355570',
-  },
-  'Game Maker Language': {
-    color: '#71b417',
-  },
-  'Gemfile.lock': {
-    color: '#701516',
-  },
-  Genie: {
-    color: '#fb855d',
-  },
-  Gherkin: {
-    color: '#5B2063',
-  },
-  Glyph: {
-    color: '#c1ac7f',
-  },
-  Gnuplot: {
-    color: '#f0a9f0',
-  },
-  Go: {
-    color: '#00ADD8',
-  },
-  Golo: {
-    color: '#88562A',
-  },
-  Gosu: {
-    color: '#82937f',
-  },
-  'Grammatical Framework': {
-    color: '#ff0000',
-  },
-  GraphQL: {
-    color: '#e10098',
-  },
-  Groovy: {
-    color: '#e69f56',
-  },
-  HTML: {
-    color: '#e34c26',
-  },
-  Hack: {
-    color: '#878787',
-  },
-  Haml: {
-    color: '#ece2a9',
-  },
-  Handlebars: {
-    color: '#f7931e',
-  },
-  Harbour: {
-    color: '#0e60e3',
-  },
-  Haskell: {
-    color: '#5e5086',
-  },
-  Haxe: {
-    color: '#df7900',
-  },
-  HiveQL: {
-    color: '#dce200',
-  },
-  HolyC: {
-    color: '#ffefaf',
-  },
-  Hy: {
-    color: '#7790B2',
-  },
-  IDL: {
-    color: '#a3522f',
-  },
-  'IGOR Pro': {
-    color: '#0000cc',
-  },
-  Idris: {
-    color: '#b30000',
-  },
-  'ImageJ Macro': {
-    color: '#99AAFF',
-  },
-  Io: {
-    color: '#a9188d',
-  },
-  Ioke: {
-    color: '#078193',
-  },
-  Isabelle: {
-    color: '#FEFE00',
-  },
-  J: {
-    color: '#9EEDFF',
-  },
-  JFlex: {
-    color: '#DBCA00',
-  },
-  JSONiq: {
-    color: '#40d47e',
-  },
-  Java: {
-    color: '#b07219',
-  },
-  JavaScript: {
-    color: '#f1e05a',
-  },
-  Jinja: {
-    color: '#a52a22',
-  },
-  Jolie: {
-    color: '#843179',
-  },
-  Jsonnet: {
-    color: '#0064bd',
-  },
-  Julia: {
-    color: '#a270ba',
-  },
-  'Jupyter Notebook': {
-    color: '#DA5B0B',
-  },
-  KRL: {
-    color: '#28430A',
-  },
-  'Kaitai Struct': {
-    color: '#773b37',
-  },
-  Kotlin: {
-    color: '#F18E33',
-  },
-  LFE: {
-    color: '#4C3023',
-  },
-  LLVM: {
-    color: '#185619',
-  },
-  LOLCODE: {
-    color: '#cc9900',
-  },
-  LSL: {
-    color: '#3d9970',
-  },
-  Lark: {
-    color: '#2980B9',
-  },
-  Lasso: {
-    color: '#999999',
-  },
-  Latte: {
-    color: '#f2a542',
-  },
-  Less: {
-    color: '#1d365d',
-  },
-  Lex: {
-    color: '#DBCA00',
-  },
-  Liquid: {
-    color: '#67b8de',
-  },
-  LiveScript: {
-    color: '#499886',
-  },
-  LookML: {
-    color: '#652B81',
-  },
-  Lua: {
-    color: '#000080',
-  },
-  MATLAB: {
-    color: '#e16737',
-  },
-  MAXScript: {
-    color: '#00a6a6',
-  },
-  MLIR: {
-    color: '#5EC8DB',
-  },
-  MQL4: {
-    color: '#62A8D6',
-  },
-  MQL5: {
-    color: '#4A76B8',
-  },
-  MTML: {
-    color: '#b7e1f4',
-  },
-  Macaulay2: {
-    color: '#d8ffff',
-  },
-  Makefile: {
-    color: '#427819',
-  },
-  Markdown: {
-    color: '#083fa1',
-  },
-  Marko: {
-    color: '#42bff2',
-  },
-  Mask: {
-    color: '#f97732',
-  },
-  Max: {
-    color: '#c4a79c',
-  },
-  Mercury: {
-    color: '#ff2b2b',
-  },
-  Meson: {
-    color: '#007800',
-  },
-  Metal: {
-    color: '#8f14e9',
-  },
-  Mirah: {
-    color: '#c7a938',
-  },
-  'Modula-3': {
-    color: '#223388',
-  },
-  Mustache: {
-    color: '#724b3b',
-  },
-  NCL: {
-    color: '#28431f',
-  },
-  NWScript: {
-    color: '#111522',
-  },
-  Nearley: {
-    color: '#990000',
-  },
-  Nemerle: {
-    color: '#3d3c6e',
-  },
-  NetLinx: {
-    color: '#0aa0ff',
-  },
-  'NetLinx+ERB': {
-    color: '#747faa',
-  },
-  NetLogo: {
-    color: '#ff6375',
-  },
-  NewLisp: {
-    color: '#87AED7',
-  },
-  Nextflow: {
-    color: '#3ac486',
-  },
-  Nim: {
-    color: '#ffc200',
-  },
-  Nit: {
-    color: '#009917',
-  },
-  Nix: {
-    color: '#7e7eff',
-  },
-  Nu: {
-    color: '#c9df40',
-  },
-  NumPy: {
-    color: '#9C8AF9',
-  },
-  Nunjucks: {
-    color: '#3d8137',
-  },
-  OCaml: {
-    color: '#3be133',
-  },
-  ObjectScript: {
-    color: '#424893',
-  },
-  'Objective-C': {
-    color: '#438eff',
-  },
-  'Objective-C++': {
-    color: '#6866fb',
-  },
-  'Objective-J': {
-    color: '#ff0c5a',
-  },
-  Odin: {
-    color: '#60AFFE',
-  },
-  Omgrofl: {
-    color: '#cabbff',
-  },
-  Opal: {
-    color: '#f7ede0',
-  },
-  OpenQASM: {
-    color: '#AA70FF',
-  },
-  Org: {
-    color: '#77aa99',
-  },
-  Oxygene: {
-    color: '#cdd0e3',
-  },
-  Oz: {
-    color: '#fab738',
-  },
-  P4: {
-    color: '#7055b5',
-  },
-  PHP: {
-    color: '#4F5D95',
-  },
-  PLSQL: {
-    color: '#dad8d8',
-  },
-  Pan: {
-    color: '#cc0000',
-  },
-  Papyrus: {
-    color: '#6600cc',
-  },
-  Parrot: {
-    color: '#f3ca0a',
-  },
-  Pascal: {
-    color: '#E3F171',
-  },
-  Pawn: {
-    color: '#dbb284',
-  },
-  Pep8: {
-    color: '#C76F5B',
-  },
-  Perl: {
-    color: '#0298c3',
-  },
-  PigLatin: {
-    color: '#fcd7de',
-  },
-  Pike: {
-    color: '#005390',
-  },
-  PogoScript: {
-    color: '#d80074',
-  },
-  PostScript: {
-    color: '#da291c',
-  },
-  PowerBuilder: {
-    color: '#8f0f8d',
-  },
-  PowerShell: {
-    color: '#012456',
-  },
-  Prisma: {
-    color: '#0c344b',
-  },
-  Processing: {
-    color: '#0096D8',
-  },
-  Prolog: {
-    color: '#74283c',
-  },
-  'Propeller Spin': {
-    color: '#7fa2a7',
-  },
-  Pug: {
-    color: '#a86454',
-  },
-  Puppet: {
-    color: '#302B6D',
-  },
-  PureBasic: {
-    color: '#5a6986',
-  },
-  PureScript: {
-    color: '#1D222D',
-  },
-  Python: {
-    color: '#3572A5',
-  },
-  'Q#': {
-    color: '#fed659',
-  },
-  QML: {
-    color: '#44a51c',
-  },
-  'Qt Script': {
-    color: '#00b841',
-  },
-  Quake: {
-    color: '#882233',
-  },
-  R: {
-    color: '#198CE7',
-  },
-  RAML: {
-    color: '#77d9fb',
-  },
-  RUNOFF: {
-    color: '#665a4e',
-  },
-  Racket: {
-    color: '#3c5caa',
-  },
-  Ragel: {
-    color: '#9d5200',
-  },
-  Raku: {
-    color: '#0000fb',
-  },
-  Rascal: {
-    color: '#fffaa0',
-  },
-  ReScript: {
-    color: '#ed5051',
-  },
-  Reason: {
-    color: '#ff5847',
-  },
-  Rebol: {
-    color: '#358a5b',
-  },
-  'Record Jar': {
-    color: '#0673ba',
-  },
-  Red: {
-    color: '#f50000',
-  },
-  "Ren'Py": {
-    color: '#ff7f7f',
-  },
-  Ring: {
-    color: '#2D54CB',
-  },
-  Riot: {
-    color: '#A71E49',
-  },
-  Roff: {
-    color: '#ecdebe',
-  },
-  Rouge: {
-    color: '#cc0088',
-  },
-  Ruby: {
-    color: '#701516',
-  },
-  Rust: {
-    color: '#dea584',
-  },
-  SAS: {
-    color: '#B34936',
-  },
-  SCSS: {
-    color: '#c6538c',
-  },
-  SQF: {
-    color: '#3F3F3F',
-  },
-  'SRecode Template': {
-    color: '#348a34',
-  },
-  SVG: {
-    color: '#ff9900',
-  },
-  SaltStack: {
-    color: '#646464',
-  },
-  Sass: {
-    color: '#a53b70',
-  },
-  Scala: {
-    color: '#c22d40',
-  },
-  Scaml: {
-    color: '#bd181a',
-  },
-  Scheme: {
-    color: '#1e4aec',
-  },
-  Self: {
-    color: '#0579aa',
-  },
-  Shell: {
-    color: '#89e051',
-  },
-  Shen: {
-    color: '#120F14',
-  },
-  Singularity: {
-    color: '#64E6AD',
-  },
-  Slash: {
-    color: '#007eff',
-  },
-  Slice: {
-    color: '#003fa2',
-  },
-  Slim: {
-    color: '#2b2b2b',
-  },
-  SmPL: {
-    color: '#c94949',
-  },
-  Smalltalk: {
-    color: '#596706',
-  },
-  Solidity: {
-    color: '#AA6746',
-  },
-  SourcePawn: {
-    color: '#f69e1d',
-  },
-  Squirrel: {
-    color: '#800000',
-  },
-  Stan: {
-    color: '#b2011d',
-  },
-  'Standard ML': {
-    color: '#dc566d',
-  },
-  Starlark: {
-    color: '#76d275',
-  },
-  StringTemplate: {
-    color: '#3fb34f',
-  },
-  Stylus: {
-    color: '#ff6347',
-  },
-  SuperCollider: {
-    color: '#46390b',
-  },
-  Svelte: {
-    color: '#ff3e00',
-  },
-  Swift: {
-    color: '#ffac45',
-  },
-  SystemVerilog: {
-    color: '#DAE1C2',
-  },
-  'TI Program': {
-    color: '#A0AA87',
-  },
-  Tcl: {
-    color: '#e4cc98',
-  },
-  TeX: {
-    color: '#3D6117',
-  },
-  Terra: {
-    color: '#00004c',
-  },
-  Turing: {
-    color: '#cf142b',
-  },
-  Twig: {
-    color: '#c1d026',
-  },
-  TypeScript: {
-    color: '#2b7489',
-  },
-  'Unified Parallel C': {
-    color: '#4e3617',
-  },
-  Uno: {
-    color: '#9933cc',
-  },
-  UnrealScript: {
-    color: '#a54c4d',
-  },
-  V: {
-    color: '#4f87c4',
-  },
-  VBA: {
-    color: '#867db1',
-  },
-  VBScript: {
-    color: '#15dcdc',
-  },
-  VCL: {
-    color: '#148AA8',
-  },
-  VHDL: {
-    color: '#adb2cb',
-  },
-  Vala: {
-    color: '#fbe5cd',
-  },
-  Verilog: {
-    color: '#b2b7f8',
-  },
-  'Vim script': {
-    color: '#199f4b',
-  },
-  'Visual Basic .NET': {
-    color: '#945db7',
-  },
-  Volt: {
-    color: '#1F1F1F',
-  },
-  Vue: {
-    color: '#2c3e50',
-  },
-  WebAssembly: {
-    color: '#04133b',
-  },
-  Wollok: {
-    color: '#a23738',
-  },
-  X10: {
-    color: '#4B6BEF',
-  },
-  XC: {
-    color: '#99DA07',
-  },
-  XQuery: {
-    color: '#5232e7',
-  },
-  XSLT: {
-    color: '#EB8CEB',
-  },
-  Xonsh: {
-    color: '#285EEF',
-  },
-  YAML: {
-    color: '#cb171e',
-  },
-  YARA: {
-    color: '#220000',
-  },
-  YASnippet: {
-    color: '#32AB90',
-  },
-  Yacc: {
-    color: '#4B6C4B',
-  },
-  ZAP: {
-    color: '#0d665e',
-  },
-  ZIL: {
-    color: '#dc75e5',
-  },
-  ZenScript: {
-    color: '#00BCD1',
-  },
-  Zephir: {
-    color: '#118f9e',
-  },
-  Zig: {
-    color: '#ec915c',
-  },
-  eC: {
-    color: '#913960',
-  },
-  jq: {
-    color: '#c7254e',
-  },
-  'mIRC Script': {
-    color: '#3d57c3',
-  },
-  mcfunction: {
-    color: '#E22837',
-  },
-  nesC: {
-    color: '#94B0C7',
-  },
-  ooc: {
-    color: '#b0b77e',
-  },
-  q: {
-    color: '#0040cd',
-  },
-  sed: {
-    color: '#64b970',
-  },
-  wdl: {
-    color: '#42f1f4',
-  },
-  wisp: {
-    color: '#7582D1',
-  },
-  xBase: {
-    color: '#403a40',
-  },
-});
+export const colors = {
+  '1C Enterprise': '#814CCC',
+  ABAP: '#E8274B',
+  'ABAP CDS': '#555e25',
+  'AGS Script': '#B9D9FF',
+  AL: '#3AA2B5',
+  AMPL: '#E6EFBB',
+  ANTLR: '#9DC3FF',
+  'API Blueprint': '#2ACCA8',
+  APL: '#5A8164',
+  'ASP.NET': '#9400ff',
+  ATS: '#1ac620',
+  ActionScript: '#882B0F',
+  Ada: '#02f88c',
+  Agda: '#315665',
+  Alloy: '#64C800',
+  AngelScript: '#C7D7DC',
+  Apex: '#1797c0',
+  'Apollo Guidance Computer': '#0B3D91',
+  AppleScript: '#101F1F',
+  Arc: '#aa2afe',
+  AspectJ: '#a957b0',
+  Assembly: '#6E4C13',
+  Asymptote: '#ff0000',
+  AutoHotkey: '#6594b9',
+  AutoIt: '#1C3552',
+  Ballerina: '#FF5000',
+  Batchfile: '#C1F12E',
+  Beef: '#a52f4e',
+  Bison: '#6A463F',
+  Blade: '#f7523f',
+  BlitzMax: '#cd6400',
+  Boo: '#d4bec1',
+  Boogie: '#c80fa0',
+  Brainfuck: '#2F2530',
+  Browserslist: '#ffd539',
+  C: '#555555',
+  'C#': '#178600',
+  'C++': '#f34b7d',
+  CSON: '#244776',
+  CSS: '#563d7c',
+  Ceylon: '#dfa535',
+  Chapel: '#8dc63f',
+  Cirru: '#ccccff',
+  Clarion: '#db901e',
+  'Classic ASP': '#6a40fd',
+  Clean: '#3F85AF',
+  Click: '#E4E6F3',
+  Clojure: '#db5855',
+  'Closure Templates': '#0d948f',
+  CoffeeScript: '#244776',
+  ColdFusion: '#ed2cd6',
+  'ColdFusion CFC': '#ed2cd6',
+  'Common Lisp': '#3fb68b',
+  'Common Workflow Language': '#B5314C',
+  'Component Pascal': '#B0CE4E',
+  Crystal: '#000100',
+  Cuda: '#3A4E3A',
+  D: '#ba595e',
+  DM: '#447265',
+  Dafny: '#FFEC25',
+  Dart: '#00B4AB',
+  DataWeave: '#003a52',
+  Dhall: '#dfafff',
+  Dockerfile: '#384d54',
+  Dogescript: '#cca760',
+  Dylan: '#6c616e',
+  E: '#ccce35',
+  ECL: '#8a1267',
+  EJS: '#a91e50',
+  EQ: '#a78649',
+  Eiffel: '#4d6977',
+  Elixir: '#6e4a7e',
+  Elm: '#60B5CC',
+  'Emacs Lisp': '#c065db',
+  EmberScript: '#FFF4F3',
+  Erlang: '#B83998',
+  'F#': '#b845fc',
+  'F*': '#572e30',
+  FLUX: '#88ccff',
+  Factor: '#636746',
+  Fancy: '#7b9db4',
+  Fantom: '#14253c',
+  Faust: '#c37240',
+  Forth: '#341708',
+  Fortran: '#4d41b1',
+  FreeMarker: '#0050b2',
+  Frege: '#00cafe',
+  Futhark: '#5f021f',
+  'G-code': '#D08CF2',
+  GAML: '#FFC766',
+  GDScript: '#355570',
+  'Game Maker Language': '#71b417',
+  'Gemfile.lock': '#701516',
+  Genie: '#fb855d',
+  Gherkin: '#5B2063',
+  Glyph: '#c1ac7f',
+  Gnuplot: '#f0a9f0',
+  Go: '#00ADD8',
+  Golo: '#88562A',
+  Gosu: '#82937f',
+  'Grammatical Framework': '#ff0000',
+  GraphQL: '#e10098',
+  Groovy: '#e69f56',
+  HTML: '#e34c26',
+  Hack: '#878787',
+  Haml: '#ece2a9',
+  Handlebars: '#f7931e',
+  Harbour: '#0e60e3',
+  Haskell: '#5e5086',
+  Haxe: '#df7900',
+  HiveQL: '#dce200',
+  HolyC: '#ffefaf',
+  Hy: '#7790B2',
+  IDL: '#a3522f',
+  'IGOR Pro': '#0000cc',
+  Idris: '#b30000',
+  'ImageJ Macro': '#99AAFF',
+  Io: '#a9188d',
+  Ioke: '#078193',
+  Isabelle: '#FEFE00',
+  J: '#9EEDFF',
+  JFlex: '#DBCA00',
+  JSONiq: '#40d47e',
+  Java: '#b07219',
+  JavaScript: '#f1e05a',
+  Jinja: '#a52a22',
+  Jolie: '#843179',
+  Jsonnet: '#0064bd',
+  Julia: '#a270ba',
+  'Jupyter Notebook': '#DA5B0B',
+  KRL: '#28430A',
+  'Kaitai Struct': '#773b37',
+  Kotlin: '#F18E33',
+  LFE: '#4C3023',
+  LLVM: '#185619',
+  LOLCODE: '#cc9900',
+  LSL: '#3d9970',
+  Lark: '#2980B9',
+  Lasso: '#999999',
+  Latte: '#f2a542',
+  Less: '#1d365d',
+  Lex: '#DBCA00',
+  Liquid: '#67b8de',
+  LiveScript: '#499886',
+  LookML: '#652B81',
+  Lua: '#000080',
+  MATLAB: '#e16737',
+  MAXScript: '#00a6a6',
+  MLIR: '#5EC8DB',
+  MQL4: '#62A8D6',
+  MQL5: '#4A76B8',
+  MTML: '#b7e1f4',
+  Macaulay2: '#d8ffff',
+  Makefile: '#427819',
+  Markdown: '#083fa1',
+  Marko: '#42bff2',
+  Mask: '#f97732',
+  Max: '#c4a79c',
+  Mercury: '#ff2b2b',
+  Meson: '#007800',
+  Metal: '#8f14e9',
+  Mirah: '#c7a938',
+  'Modula-3': '#223388',
+  Mustache: '#724b3b',
+  NCL: '#28431f',
+  NWScript: '#111522',
+  Nearley: '#990000',
+  Nemerle: '#3d3c6e',
+  NetLinx: '#0aa0ff',
+  'NetLinx+ERB': '#747faa',
+  NetLogo: '#ff6375',
+  NewLisp: '#87AED7',
+  Nextflow: '#3ac486',
+  Nim: '#ffc200',
+  Nit: '#009917',
+  Nix: '#7e7eff',
+  Nu: '#c9df40',
+  NumPy: '#9C8AF9',
+  Nunjucks: '#3d8137',
+  OCaml: '#3be133',
+  ObjectScript: '#424893',
+  'Objective-C': '#438eff',
+  'Objective-C++': '#6866fb',
+  'Objective-J': '#ff0c5a',
+  Odin: '#60AFFE',
+  Omgrofl: '#cabbff',
+  Opal: '#f7ede0',
+  OpenQASM: '#AA70FF',
+  Org: '#77aa99',
+  Oxygene: '#cdd0e3',
+  Oz: '#fab738',
+  P4: '#7055b5',
+  PHP: '#4F5D95',
+  PLSQL: '#dad8d8',
+  Pan: '#cc0000',
+  Papyrus: '#6600cc',
+  Parrot: '#f3ca0a',
+  Pascal: '#E3F171',
+  Pawn: '#dbb284',
+  Pep8: '#C76F5B',
+  Perl: '#0298c3',
+  PigLatin: '#fcd7de',
+  Pike: '#005390',
+  PogoScript: '#d80074',
+  PostScript: '#da291c',
+  PowerBuilder: '#8f0f8d',
+  PowerShell: '#012456',
+  Prisma: '#0c344b',
+  Processing: '#0096D8',
+  Prolog: '#74283c',
+  'Propeller Spin': '#7fa2a7',
+  Pug: '#a86454',
+  Puppet: '#302B6D',
+  PureBasic: '#5a6986',
+  PureScript: '#1D222D',
+  Python: '#3572A5',
+  'Q#': '#fed659',
+  QML: '#44a51c',
+  'Qt Script': '#00b841',
+  Quake: '#882233',
+  R: '#198CE7',
+  RAML: '#77d9fb',
+  RUNOFF: '#665a4e',
+  Racket: '#3c5caa',
+  Ragel: '#9d5200',
+  Raku: '#0000fb',
+  Rascal: '#fffaa0',
+  ReScript: '#ed5051',
+  Reason: '#ff5847',
+  Rebol: '#358a5b',
+  'Record Jar': '#0673ba',
+  Red: '#f50000',
+  "Ren'Py": '#ff7f7f',
+  Ring: '#2D54CB',
+  Riot: '#A71E49',
+  Roff: '#ecdebe',
+  Rouge: '#cc0088',
+  Ruby: '#701516',
+  Rust: '#dea584',
+  SAS: '#B34936',
+  SCSS: '#c6538c',
+  SQF: '#3F3F3F',
+  'SRecode Template': '#348a34',
+  SVG: '#ff9900',
+  SaltStack: '#646464',
+  Sass: '#a53b70',
+  Scala: '#c22d40',
+  Scaml: '#bd181a',
+  Scheme: '#1e4aec',
+  Self: '#0579aa',
+  Shell: '#89e051',
+  Shen: '#120F14',
+  Singularity: '#64E6AD',
+  Slash: '#007eff',
+  Slice: '#003fa2',
+  Slim: '#2b2b2b',
+  SmPL: '#c94949',
+  Smalltalk: '#596706',
+  Solidity: '#AA6746',
+  SourcePawn: '#f69e1d',
+  Squirrel: '#800000',
+  Stan: '#b2011d',
+  'Standard ML': '#dc566d',
+  Starlark: '#76d275',
+  StringTemplate: '#3fb34f',
+  Stylus: '#ff6347',
+  SuperCollider: '#46390b',
+  Svelte: '#ff3e00',
+  Swift: '#ffac45',
+  SystemVerilog: '#DAE1C2',
+  'TI Program': '#A0AA87',
+  Tcl: '#e4cc98',
+  TeX: '#3D6117',
+  Terra: '#00004c',
+  Turing: '#cf142b',
+  Twig: '#c1d026',
+  TypeScript: '#2b7489',
+  'Unified Parallel C': '#4e3617',
+  Uno: '#9933cc',
+  UnrealScript: '#a54c4d',
+  V: '#4f87c4',
+  VBA: '#867db1',
+  VBScript: '#15dcdc',
+  VCL: '#148AA8',
+  VHDL: '#adb2cb',
+  Vala: '#fbe5cd',
+  Verilog: '#b2b7f8',
+  'Vim script': '#199f4b',
+  'Visual Basic .NET': '#945db7',
+  Volt: '#1F1F1F',
+  Vue: '#2c3e50',
+  WebAssembly: '#04133b',
+  Wollok: '#a23738',
+  X10: '#4B6BEF',
+  XC: '#99DA07',
+  XQuery: '#5232e7',
+  XSLT: '#EB8CEB',
+  Xonsh: '#285EEF',
+  YAML: '#cb171e',
+  YARA: '#220000',
+  YASnippet: '#32AB90',
+  Yacc: '#4B6C4B',
+  ZAP: '#0d665e',
+  ZIL: '#dc75e5',
+  ZenScript: '#00BCD1',
+  Zephir: '#118f9e',
+  Zig: '#ec915c',
+  eC: '#913960',
+  jq: '#c7254e',
+  'mIRC Script': '#3d57c3',
+  mcfunction: '#E22837',
+  nesC: '#94B0C7',
+  ooc: '#b0b77e',
+  q: '#0040cd',
+  sed: '#64b970',
+  wdl: '#42f1f4',
+  wisp: '#7582D1',
+  xBase: '#403a40',
+};
+
+export type Colors = keyof typeof colors;

--- a/test/linguist.test.js
+++ b/test/linguist.test.js
@@ -1,21 +1,9 @@
 const linguist = require('../dist/linguist');
 
 test('GetHexColour() JS uppercase', () => {
-  expect(linguist.GetHexColour('JavaScript')).toBe('#f1e05a');
-});
-
-test('GetHexColour() JS lowercase', () => {
-  expect(linguist.GetHexColour('javascript')).toBe('#f1e05a');
-});
-
-test('GetHexColour() Swift lowercase', () => {
-  expect(linguist.GetHexColour('swift')).toBe('#ffac45');
-});
-
-test('GetHexColour() unknown language', () => {
-  expect(linguist.GetHexColour('unobtainium')).toBe('#000');
+  expect(linguist.getHexColour('JavaScript')).toBe('#f1e05a');
 });
 
 test('GetColourMap() returns Map', () => {
-  expect(linguist.GetColourMap() instanceof Map).toBe(true);
+  expect(linguist.getColourMap() instanceof Object).toBe(true);
 });


### PR DESCRIPTION
## Changes

- Added type-safety to `getHexColour`
  - This also means you don't need to return `#000' for languages that don't exist as those will simply not be allowed
  - Also gives that sweeeeeet autocomplete in VSCode & enforces correct args
- Removed some unncessary tests
- Simplified map function and flattened the main colors object 
- Also renamed functions to `camelCase` because pls follow conventions

![image](https://user-images.githubusercontent.com/43642399/113586114-04000a80-9625-11eb-88bd-98cb3452a22c.png)
